### PR TITLE
New parameter on search event to prevent logging the search to the an…

### DIFF
--- a/Scenariodoc/events.md
+++ b/Scenariodoc/events.md
@@ -27,6 +27,7 @@ Arguments | Type | Usage
 ------------ | ------------- | ----------------
 queryText | string | The query to send. Leave "blank" for a random query
 goodQuery | boolean | If the random query should be a good or a bad query
+logEvent | boolean | If the event should be logged in the analytics (optional, default = true)
 caseSearch | boolean | If the query comes from a Case Creation interface
 inputTitle | string | The title of the input that triggered the search if it was a case search
 customData | object | Custom data to be sent alongside the event.
@@ -39,6 +40,7 @@ customData | object | Custom data to be sent alongside the event.
     "arguments" : {
         "queryText" : "",
         "goodQuery" : true,
+        "logEvent" : true,
         "caseSearch" : true,
         "inputTitle" : "Product",
         "customData" : {

--- a/scenariolib/event_search.go
+++ b/scenariolib/event_search.go
@@ -35,11 +35,6 @@ func newSearchEvent(e *JSONEvent, c *Config) (*SearchEvent, error) {
 		if se.logEvent, validCast = e.Arguments["logEvent"].(bool); !validCast {
 			return nil, errors.New("Parameter logEvent must be of type bool in SearchEvent")
 		}
-		if (se.logEvent) {
-			print("Logging search event")
-		} else {
-			print("Not logging search event")
-		}
 	} else {
 		se.logEvent = true
 	}

--- a/scenariolib/event_search.go
+++ b/scenariolib/event_search.go
@@ -38,6 +38,8 @@ func newSearchEvent(e *JSONEvent, c *Config) (*SearchEvent, error) {
 	} else {
 		se.logEvent = true
 	}
+	Info.Printf("Will log search event to analytics: (%t)", se.logEvent)
+
 	if goodQuery, validCast = e.Arguments["goodQuery"].(bool); !validCast {
 		return nil, errors.New("Parameter goodQuery must be of type bool in SearchEvent")
 	}


### PR DESCRIPTION
New parameter on search event to prevent logging the search to the analytics (executes the query only, we will need this to support logging View events, where we need to search first to get documents to log, but we don't want the query to be logged)